### PR TITLE
fix: node_modules folder REMOVED

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # ⚡ Geral (Evita arquivos desnecessários no repositório)
+node_modules/
 .DS_Store
 Thumbs.db
 *.log
@@ -9,7 +10,6 @@ Thumbs.db
 *.swo
 
 # ⚡ Node.js (Backend)
-node_modules/
 dist/
 build/
 .env
@@ -23,7 +23,6 @@ package-lock.json
 yarn.lock
 
 # ⚡ React.js (Frontend)
-node_modules/
 build/
 .cache/
 public/


### PR DESCRIPTION
prestar atencao para nao duplicar o node_modules no arquivo .gitignore, pois um comando esta anulando o outro e subindo muito lixo para o repo remoto!!!